### PR TITLE
fix(screenshot): respect width/height parameters for viewport-only capture

### DIFF
--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -29,17 +29,17 @@ export class ScreenshotTool extends BaseTool {
       },
       selector: {
         type: 'string',
-        description: 'CSS selector for element to screenshot (optional, full page if not provided)',
+        description: 'CSS selector for element to screenshot (optional, viewport/full page if not provided)',
       },
       width: {
         type: 'number',
-        description: 'Width in pixels (default: 800)',
+        description: 'Viewport width in pixels. When specified, captures viewport only instead of full page (default: 800)',
         minimum: 100,
         maximum: 4096,
       },
       height: {
         type: 'number',
-        description: 'Height in pixels (default: 600)',
+        description: 'Viewport height in pixels. When specified, captures viewport only instead of full page (default: 600)',
         minimum: 100,
         maximum: 4096,
       },
@@ -118,13 +118,14 @@ export class ScreenshotTool extends BaseTool {
         screenshotInfo.selector = validatedParams.selector;
         screenshotInfo.type = 'element';
       } else {
-        // Screenshot full page
+        // Screenshot full page or viewport
+        const useFullPage = !validatedParams.width && !validatedParams.height;
         screenshotBuffer = await this.safeScreenshot(page, {
           type: 'png',
-          fullPage: true,
+          fullPage: useFullPage,
         }) as Buffer;
 
-        screenshotInfo.type = 'fullpage';
+        screenshotInfo.type = useFullPage ? 'fullpage' : 'viewport';
       }
 
       const duration = Date.now() - startTime;
@@ -142,7 +143,7 @@ export class ScreenshotTool extends BaseTool {
       if (validatedParams.selector) {
         message += ` (element: ${validatedParams.selector})`;
       } else {
-        message += ' (full page)';
+        message += screenshotInfo.type === 'fullpage' ? ' (full page)' : ' (viewport)';
       }
       message += `\nSize: ${Math.round(screenshotBuffer.length / 1024)}KB`;
       message += `\nDuration: ${duration}ms`;


### PR DESCRIPTION
When width/height parameters are specified, the screenshot now captures only the viewport instead of the full page. Previously, fullPage was always true, causing screenshots to exceed dimension limits despite viewport size settings.

Without this I had these problems:
```
⏺ puppeteer - puppeteer_screenshot (MCP)(name: "mobile-header-top", width: 400,
height: 800)
  ⎿  Screenshot 'mobile-header-top' captured successfully (full page)
     Size: 1475KB
     Duration: 460ms
     Page: <...>
  ⎿  [Image]
  ⎿ API Error: 400 {"type":"error","error":{"type":"invalid_request_error","messa
ge":"messages.3.content.5.image.source.base64.data: At least one of the image
dimensions exceed max allowed size: 8000
    pixels"},"request_id":"req_011CTpQX47T6SsFDMPXrCuof"}
```